### PR TITLE
Fix getManualLicenseFile

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Request manual activation file
         id: getManualLicenseFile
         # https://github.com/game-ci/unity-request-activation-file/releases/
-        uses: game-ci/unity-request-manual-activation-file@v2.0-alpha-1
+        uses: game-ci/unity-request-activation-file@v2.0-alpha-1
       # Upload artifact (Unity_v20XX.X.XXXX.alf)
       - name: Expose as artifact
         uses: actions/upload-artifact@v1


### PR DESCRIPTION
A quick tread through using this amazing example from scratch revealed that the action name referenced was slightly off.

[Quick reference and sanity check of the referenced action](https://github.com/game-ci/unity-request-activation-file/releases/)